### PR TITLE
feat: Nuevos tests para invalid target user follow y unfollow

### DIFF
--- a/src/test/java/org/socialmeli/be_java_hisp_w24_g04/unittest/service/UserServiceTests.java
+++ b/src/test/java/org/socialmeli/be_java_hisp_w24_g04/unittest/service/UserServiceTests.java
@@ -226,7 +226,7 @@ public class UserServiceTests {
         Integer userIdToFollow = 2;
 
         Mockito.when(userRepository.get(userId)).thenReturn(Optional.of(user));
-        Mockito.when(userRepository.get(userId)).thenReturn(Optional.empty());
+        Mockito.when(userRepository.get(userIdToFollow)).thenReturn(Optional.empty());
 
         // act & assert
         Assertions.assertThrows(NotFoundException.class, () -> userService.follow(userId, userIdToFollow));

--- a/src/test/java/org/socialmeli/be_java_hisp_w24_g04/unittest/service/UserServiceTests.java
+++ b/src/test/java/org/socialmeli/be_java_hisp_w24_g04/unittest/service/UserServiceTests.java
@@ -217,6 +217,22 @@ public class UserServiceTests {
     }
 
     @Test
+    public void testFollowInvalidTargetUser() {
+        // arrange
+        Integer userId = 1;
+        User user = new User();
+        user.setUserId(userId);
+
+        Integer userIdToFollow = 2;
+
+        Mockito.when(userRepository.get(userId)).thenReturn(Optional.of(user));
+        Mockito.when(userRepository.get(userId)).thenReturn(Optional.empty());
+
+        // act & assert
+        Assertions.assertThrows(NotFoundException.class, () -> userService.follow(userId, userIdToFollow));
+    }
+
+    @Test
     public void testUnfollow() {
         // arrange
         Integer userId = 1;
@@ -246,6 +262,22 @@ public class UserServiceTests {
         Integer userIdToUnfollow = 2;
 
         Mockito.when(userRepository.get(userId)).thenReturn(Optional.empty());
+
+        // act & assert
+        Assertions.assertThrows(NotFoundException.class, () -> userService.unfollow(userId, userIdToUnfollow));
+    }
+
+    @Test
+    public void testUnfollowInvalidTargetUser() {
+        // arrange
+        Integer userId = 1;
+        User user = new User();
+        user.setUserId(userId);
+
+        Integer userIdToUnfollow = 2;
+
+        Mockito.when(userRepository.get(userId)).thenReturn(Optional.of(user));
+        Mockito.when(userRepository.get(userIdToUnfollow)).thenReturn(Optional.empty());
 
         // act & assert
         Assertions.assertThrows(NotFoundException.class, () -> userService.unfollow(userId, userIdToUnfollow));


### PR DESCRIPTION
Agregué tests para follow y unfollow en el caso en el que el usuario que hace la request es válido pero el usuario target es inválido. No es super necesario, pero es para cumplir con el caso "sad path" de las tareas 1 y 2 que piden lanzar una excepción.